### PR TITLE
Replace problematic URLShortener regex with httpurl requirement

### DIFF
--- a/Source/URLShortener.popclipext/Config.plist
+++ b/Source/URLShortener.popclipext/Config.plist
@@ -17,8 +17,10 @@
 			<string>urlshortener.py</string>
 			<key>Title</key>
             <string>URL Shortener</string>
-            <key>Regular Expression</key>
-            <string>[^\s*]?(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$</string>
+			<key>Requirements</key>
+			<array>
+				<string>httpurl</string>
+			</array>
 		</dict>
 	</array>
 	<key>Credits</key>


### PR DESCRIPTION
The regex for the URL Shortener extension can cause PopClip to hang (100% CPU usage) when evaluated against certain strings.

The regex is `^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$`. A sample string that makes it hang is `https://www.example.com/test/test/test?query=1`.

(I think the problem is to do with the nested `*` in the last grouping meaning it can keep capturing empty groups indefinitely and never get to the end of the input.)

In this pull request I have removed the regex and replaced it with the `httpurl` requirement instead, which is the better way to do it anyway.
